### PR TITLE
Made client lazy

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,7 +7,7 @@
             <argument>%setono_gls_webservice.wsdl%</argument>
         </service>
 
-        <service id="setono_gls_webservice.soap_client" class="\SoapClient">
+        <service id="setono_gls_webservice.soap_client" class="\SoapClient" lazy="true">
             <factory service="setono_gls_webservice.factory.soap_client" method="create"/>
             <argument>%setono_gls_webservice.options%</argument>
         </service>


### PR DESCRIPTION
To prevent crashing everything if WSDL is not reachable

```
$ bin/console

In SoapClientFactory.php line 26:                                                                                       
  SOAP-ERROR: Parsing WSDL: Couldn't load from 'https://www.gls.dk/webservices_v4/wsShopFinder.asmx?WSDL' : failed to load external entity "https://www.gls.dk/webservices_v4/wsShopFinder.asmx?WSDL" 
```